### PR TITLE
Bump build number to 2 and rerender to upload linux-aarch64 builds compatible with boost 1.86

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set libcamera_version = "0.4.0" %}
 {% set libcamera_rpi_version = "0.4.0+rpt20250213" %}
 {% set rpi_url_safe_version = libcamera_rpi_version | urlencode %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% if variant == "upstream" %}
   # install upstream variant by dafault


### PR DESCRIPTION
Fix https://github.com/conda-forge/libcamera-feedstock/issues/4 .

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
