### PR TITLE
Fix IPA proxy/module/config path resolution under conda RUNPATH

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -28,90 +28,135 @@ jobs:
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_64_python3.11.____cpythonvariantupstream
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_64_python3.12.____cpythonvariantupstream
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_64_python3.13.____cp313variantupstream
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_64_python3.14.____cp314variantupstream
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_python3.10.____cpythonvariantrpi_fork
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_python3.10.____cpythonvariantupstream
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_python3.11.____cpythonvariantrpi_fork
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_python3.11.____cpythonvariantupstream
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_python3.12.____cpythonvariantrpi_fork
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_python3.12.____cpythonvariantupstream
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_python3.13.____cp313variantrpi_fork
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_python3.13.____cp313variantupstream
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_python3.14.____cp314variantrpi_fork
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
           - CONFIG: linux_aarch64_python3.14.____cp314variantupstream
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            tools_install_dir: ~/miniforge3
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
     steps:
 
     - name: Checkout code
@@ -121,11 +166,13 @@ jobs:
       id: build-linux
       if: matrix.os == 'ubuntu'
       env:
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
         CI: github_actions
-        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.CONDA_FORGE_DOCKER_RUN_ARGS }}"
+        CONDA_FORGE_DOCKER_RUN_ARGS: "${{ matrix.docker_run_args }}"
         BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
         FEEDSTOCK_TOKEN: ${{ secrets.FEEDSTOCK_TOKEN }}
         STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
@@ -145,6 +192,8 @@ jobs:
         else
           export IS_PR_BUILD="False"
         fi
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         echo "::endgroup::"
         ./.scripts/run_docker_build.sh
 
@@ -152,6 +201,8 @@ jobs:
       id: build-macos
       if: matrix.os == 'macos'
       env:
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         CI: github_actions
@@ -170,6 +221,8 @@ jobs:
         else
           export IS_PR_BUILD="False"
         fi
+        export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
+        export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         ./.scripts/run_osx_build.sh
 
     - name: Build on windows
@@ -182,10 +235,8 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
-        # default value; make it explicit, as it needs to match with artefact
-        # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_PATH: C:\bld
-        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
+        MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
+        CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -36,7 +36,7 @@ mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-
 echo > /opt/conda/conda-meta/history
 micromamba install --root-prefix ~/.conda --prefix /opt/conda \
     --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc

--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>GitHub Actions</td>
+    <td>
+      <a href="https://github.com/conda-forge/libcamera-feedstock/actions/workflows/conda-build.yml">
+        <img src="https://github.com/conda-forge/libcamera-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+      </a>
+    </td>
+  </tr>
 </table>
 
 Current release info

--- a/recipe/0002-conda-installed-paths.patch
+++ b/recipe/0002-conda-installed-paths.patch
@@ -1,0 +1,47 @@
+From: Carlo Dri <carlo.dri@gmail.com>
+Date: Wed, 10 Jun 2026 08:27:41 +0000
+Subject: [PATCH] Treat libcamera as installed under conda RUNPATH
+
+conda-forge injects a DT_RUNPATH into every relocatable library, which
+defeats isLibcameraInstalled()'s heuristic and routes IPA module, IPA
+proxy worker, IPA config and pipeline-config lookups into a non-existent
+build tree ($PREFIX/../src/...). This makes IPAProxy::resolvePath()
+return an empty path and abort with a segfault on camera enumeration.
+
+Report the library as installed so the compiled-in install dirs
+(IPA_MODULE_DIR, IPA_PROXY_DIR, IPA_CONFIG_DIR, LIBCAMERA_DATA_DIR) are
+used. LIBCAMERA_IPA_*_PATH env overrides are checked independently and
+keep working.
+---
+ src/libcamera/source_paths.cpp | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/src/libcamera/source_paths.cpp b/src/libcamera/source_paths.cpp
+index 1af5386..0bf50d4 100644
+--- a/src/libcamera/source_paths.cpp
++++ b/src/libcamera/source_paths.cpp
+@@ -40,14 +40,15 @@ namespace {
+ bool isLibcameraInstalled()
+ {
+ 	/*
+-	 * DT_RUNPATH (DT_RPATH when the linker uses old dtags) is removed on
+-	 * install.
++	 * Upstream uses the presence of DT_RUNPATH/DT_RPATH (stripped by meson
++	 * on install) as the "not installed" signal. conda-forge injects a
++	 * RUNPATH into every relocatable library, so that heuristic always
++	 * misfires and sends IPA module/proxy/config and pipeline-config lookups
++	 * into a non-existent build tree. In a conda environment the library is
++	 * always installed; report it as such so the standard installed search
++	 * paths are used. Developer overrides via LIBCAMERA_IPA_*_PATH are checked
++	 * independently and remain functional.
+ 	 */
+-	for (const ElfW(Dyn) *dyn = _DYNAMIC; dyn->d_tag != DT_NULL; ++dyn) {
+-		if (dyn->d_tag == DT_RUNPATH || dyn->d_tag == DT_RPATH)
+-			return false;
+-	}
+-
+ 	return true;
+ }
+ 
+-- 
+2.43.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set libcamera_version = "0.5.2" %}
 {% set libcamera_rpi_version = "0.5.2+rpt20250903" %}
 {% set rpi_url_safe_version = libcamera_rpi_version | urlencode %}
-{% set build = 4 %}
+{% set build = 5 %}
 
 {% if variant == "upstream" %}
   # install upstream variant by dafault
@@ -29,6 +29,7 @@ source:
     - memfd_symbols.patch
     # When cross compiling it is important to specify this to help find libevent
     - 0001-Specify-to-use-the-prefix-include-directory-to-help-.patch
+    - 0002-conda-installed-paths.patch
 
 build:
   number: {{ build }}


### PR DESCRIPTION
Note: crafted by Claude Opus 4.8 🤖 with my guidance

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
## Problem

On a relocated conda env, enumerating cameras (`cam -l`, and therefore any
picamera2 use) segfaults:

    ERROR IPAProxy raspberrypi_ipa_proxy.cpp:52 Failed to get proxy worker path
    ERROR IPAManager ipa_manager.h:47 Failed to load proxy
    Segmentation fault

Root cause: `isLibcameraInstalled()` (`src/libcamera/source_paths.cpp`)
decides "installed vs build tree" solely by the presence of a
`DT_RUNPATH`/`DT_RPATH` tag, which upstream meson strips on install.
conda-forge injects a RUNPATH into every relocatable library, so the check
always returns false. `libcameraBuildPath()` then computes
`dirname(libcamera.so)/../../` → the parent of the env prefix, and the
build-tree subpaths (`<root>/src/ipa`, `<root>/src/libcamera/proxy/worker`,
…) don't exist.

This misroutes four lookups: IPA modules (`ipa_manager.cpp`), IPA proxy
workers (`ipa_proxy.cpp::resolvePath`), IPA config files
(`ipa_proxy.cpp::configurationFile`) and pipeline config files
(`pipeline_handler.cpp::configurationFile`). `resolvePath()` is fatal because
it returns early without falling through to the installed `IPA_PROXY_DIR`.

## Fix

Patch `isLibcameraInstalled()` to return `true`. A conda package is always
installed, so all four consumers fall through to their compiled-in install
dirs (`IPA_MODULE_DIR`, `IPA_PROXY_DIR`, `IPA_CONFIG_DIR`,
`LIBCAMERA_DATA_DIR`). The `LIBCAMERA_IPA_*_PATH` env overrides are checked
before and independently of this flag, so the developer escape hatch is
unaffected.

## Verification

On a Pi 5 (imx708), setting `LIBCAMERA_IPA_{PROXY,MODULE,CONFIG}_PATH` to the
installed dirs reproduces the working behaviour the patch makes default:
`cam -l` enumerates the camera with no segfault.

## Refs

- `src/libcamera/source_paths.cpp` — `isLibcameraInstalled`, `libcameraBuildPath`
- `src/libcamera/ipa_proxy.cpp:218` (resolvePath early-return)