### PR TITLE
fix: make rpi variant install by default on aarch64

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,14 @@ context:
   libcamera_rpi_version: "0.7.1+rpt20260609"
   # '+' must be percent-encoded for the GitHub release URL
   rpi_url_safe_version: ${{ libcamera_rpi_version | replace("+", "%2B") }}
-  number_base: 1
+  number_base: 2
+  # rpi_fork sorts above upstream so a bare `libcamera` dep resolves to the
+  # fork by default on aarch64 (where both variants exist); upstream stays
+  # installable explicitly via `libcamera=*=*_upstream`. The offsets also clear
+  # the previously published 0.7.1 builds (old upstream was 1+100=101), so each
+  # new variant supersedes its predecessor.
+  upstream_build_number: ${{ number_base + 100 }}
+  rpi_build_number: ${{ number_base + 200 }}
 
 recipe:
   name: libcamera
@@ -33,7 +40,7 @@ source:
         - 0002-conda-installed-paths.patch
 
 build:
-  number: ${{ number_base + 100 if variant == "upstream" else number_base }}
+  number: ${{ rpi_build_number if variant == "rpi_fork" else upstream_build_number }}
   skip:
     - not linux
     - variant == "rpi_fork" and not aarch64
@@ -121,7 +128,7 @@ outputs:
       run:
         # Can't pin exact because of the python build matrix; match the
         # version + build number + variant via the build-string glob instead.
-        - libcamera ==${{ libcamera_version }} *_${{ number_base }}_${{ variant }}
+        - libcamera ==${{ libcamera_version }} *_${{ rpi_build_number }}_${{ variant }}
     tests:
       # Metapackage: confirm it resolves the pin and co-installs the
       # matching libcamera build (the run dep lands in the test env).


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes #29 
<!--
Please add any other relevant info below:
-->
